### PR TITLE
Allow float durations, fix Edf.WriteNotes()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.syso
 *.o
 *.a
+.idea

--- a/edfOps.go
+++ b/edfOps.go
@@ -12,8 +12,8 @@ import (
  ******************/
 
 // GetDuration gets the duration of the file in seconds
-func (edf Edf) GetDuration() int {
-	v, oops := strconv.Atoi(strings.TrimSpace(edf.Header["duration"]))
+func (edf Edf) GetDuration() float64 {
+	v, oops := strconv.ParseFloat(strings.TrimSpace(edf.Header["duration"]), 64)
 	if oops != nil {
 		panic(oops)
 	}

--- a/edfWrite.go
+++ b/edfWrite.go
@@ -142,7 +142,7 @@ func (edf *Edf) WriteNotes() string {
 	which := getAnnotationsChannel(edf.Header)
 	outlet := ""
 
-	if which > 0 && which < len(edf.Records) {
+	if which >= 0 && which < len(edf.Records) {
 		annotations := convertInt16ToByte(edf.Records[which])
 		outlet += fmt.Sprintf("%s\n", formatAnnotations(annotations))
 	}


### PR DESCRIPTION
I'm using this library to parse EDF+ files from my ResMed CPAP machine, and I ran into a couple small issues that I'm offering the PR to fix:
1. In my .edf files, the duration header can be a decimal value like `60.0`. Now `Edf.GetDuration()` returns a `float64`.
2. There was a bug in Edf.WriteNotes() where the index of the annotations channel was only allowed to be `> 0`, while in my data files, even the first (index 0) channel can contain annotations.

Thanks for providing this project!